### PR TITLE
34/admin logic

### DIFF
--- a/packages/backend/index.js
+++ b/packages/backend/index.js
@@ -7,7 +7,7 @@ const bodyParser = require("body-parser");
 // Firebase set up
 const firebaseAdmin = require("firebase-admin");
 const firebaseServiceAccount = require("./firebaseServiceAccountKey.json");
-const { jwtAuth } = require("./middlewares/auth");
+const { jwtAuth, jwtAdminAuth } = require("./middlewares/auth");
 
 const app = express();
 
@@ -101,9 +101,9 @@ app.post("/sign", async (request, response) => {
   }
 });
 
-app.post("/challenges", async (request, response) => {
-  // ToDo. Auth / Validate route. https://github.com/moonshotcollective/scaffold-directory/issues/18
-  const { challengeId, deployedUrl, branchUrl, address } = request.body;
+app.post("/challenges", jwtAuth, async (request, response) => {
+  const { challengeId, deployedUrl, branchUrl } = request.body;
+  const address = request.address;
   console.log("POST /challenges: ", address, challengeId, deployedUrl, branchUrl);
 
   const userRef = await database.collection("users").doc(address);
@@ -136,8 +136,7 @@ async function setChallengeStatus(userAddress, challengeId, newStatus, comment) 
   await userRef.set({ challenges: existingChallenges });
 }
 
-app.patch("/challenges", async (request, response) => {
-  // ToDo. Auth. Only admins
+app.patch("/challenges", jwtAdminAuth, async (request, response) => {
   const { userAddress, challengeId, newStatus, comment } = request.body.params;
   if (newStatus !== "ACCEPTED" && newStatus !== "REJECTED") {
     response.status(400).send("Invalid status");
@@ -165,8 +164,7 @@ async function getAllChallenges() {
   return allChallenges;
 }
 
-app.get("/challenges", async (request, response) => {
-  // ToDo. Auth. Only admins
+app.get("/challenges", jwtAdminAuth, async (request, response) => {
   const status = request.query.status;
   const allChallenges = await getAllChallenges();
   if (status == null) {
@@ -177,6 +175,10 @@ app.get("/challenges", async (request, response) => {
 });
 
 app.get("/auth-jwt-restricted", jwtAuth, (req, res) => {
+  res.send(`all working! 👌. Successfully authenticated request from ${req.address}`);
+});
+
+app.get("/auth-jwt-admin-restricted", jwtAdminAuth, (req, res) => {
   res.send(`all working! 👌. Successfully authenticated request from ${req.address}`);
 });
 

--- a/packages/backend/index.js
+++ b/packages/backend/index.js
@@ -7,7 +7,7 @@ const bodyParser = require("body-parser");
 // Firebase set up
 const firebaseAdmin = require("firebase-admin");
 const firebaseServiceAccount = require("./firebaseServiceAccountKey.json");
-const { jwtAuth, jwtAdminAuth } = require("./middlewares/auth");
+const { userOnly, adminOnly } = require("./middlewares/auth");
 
 const app = express();
 
@@ -101,7 +101,7 @@ app.post("/sign", async (request, response) => {
   }
 });
 
-app.post("/challenges", jwtAuth, async (request, response) => {
+app.post("/challenges", userOnly, async (request, response) => {
   const { challengeId, deployedUrl, branchUrl } = request.body;
   const address = request.address;
   console.log("POST /challenges: ", address, challengeId, deployedUrl, branchUrl);
@@ -136,7 +136,7 @@ async function setChallengeStatus(userAddress, challengeId, newStatus, comment) 
   await userRef.update({ challenges: existingChallenges });
 }
 
-app.patch("/challenges", jwtAdminAuth, async (request, response) => {
+app.patch("/challenges", adminOnly, async (request, response) => {
   const { userAddress, challengeId, newStatus, comment } = request.body.params;
   if (newStatus !== "ACCEPTED" && newStatus !== "REJECTED") {
     response.status(400).send("Invalid status");
@@ -164,7 +164,7 @@ async function getAllChallenges() {
   return allChallenges;
 }
 
-app.get("/challenges", jwtAdminAuth, async (request, response) => {
+app.get("/challenges", adminOnly, async (request, response) => {
   const status = request.query.status;
   const allChallenges = await getAllChallenges();
   if (status == null) {
@@ -174,11 +174,11 @@ app.get("/challenges", jwtAdminAuth, async (request, response) => {
   }
 });
 
-app.get("/auth-jwt-restricted", jwtAuth, (req, res) => {
+app.get("/auth-jwt-restricted", userOnly, (req, res) => {
   res.send(`all working! 👌. Successfully authenticated request from ${req.address}`);
 });
 
-app.get("/auth-jwt-admin-restricted", jwtAdminAuth, (req, res) => {
+app.get("/auth-jwt-admin-restricted", adminOnly, (req, res) => {
   res.send(`all working! 👌. Successfully authenticated request from ${req.address}`);
 });
 

--- a/packages/backend/index.js
+++ b/packages/backend/index.js
@@ -117,7 +117,7 @@ app.post("/challenges", jwtAuth, async (request, response) => {
       branchUrl,
       deployedUrl,
     };
-    await userRef.set({ challenges: existingChallenges });
+    await userRef.update({ challenges: existingChallenges });
     response.sendStatus(200);
   } else {
     response.status(404).send("User not found!");
@@ -133,7 +133,7 @@ async function setChallengeStatus(userAddress, challengeId, newStatus, comment) 
     status: newStatus,
     reviewComment: comment != null ? comment : "",
   };
-  await userRef.set({ challenges: existingChallenges });
+  await userRef.update({ challenges: existingChallenges });
 }
 
 app.patch("/challenges", jwtAdminAuth, async (request, response) => {

--- a/packages/backend/index.js
+++ b/packages/backend/index.js
@@ -92,8 +92,7 @@ app.post("/sign", async (request, response) => {
         userObject = user.data();
       }
 
-      // TODO get isAdmin from the userObject
-      const jwt = await firebaseAdmin.auth().createCustomToken(recovered, { isAdmin: false });
+      const jwt = await firebaseAdmin.auth().createCustomToken(recovered, { isAdmin: !!userObject.isAdmin });
 
       response.json({ ...userObject, token: jwt });
     } else {

--- a/packages/backend/middlewares/auth.js
+++ b/packages/backend/middlewares/auth.js
@@ -1,4 +1,4 @@
-var jwt = require("jsonwebtoken");
+const jwt = require("jsonwebtoken");
 const serviceAccount = require("../firebaseServiceAccountKey.json");
 
 /**
@@ -19,7 +19,7 @@ const serviceAccount = require("../firebaseServiceAccountKey.json");
  * @param {Express.Response} res
  * @param {Express.NextFunction} next
  */
-const jwtAuth = (req, res, next) => {
+const userOnly = (req, res, next) => {
   const tokenHeader = req.headers.authorization;
   const addressHeader = req.headers.address;
   if (!tokenHeader) {
@@ -66,9 +66,9 @@ const jwtAuth = (req, res, next) => {
  * @param {Express.Response} res
  * @param {Express.NextFunction} next
  */
-const jwtAdminAuth = (req, res, next) => {
-  jwtAuth(req, res, () => {
-    // Added by jwtAuth
+const adminOnly = (req, res, next) => {
+  userOnly(req, res, () => {
+    // Added by userOnly
     if (!req.isAdmin) {
       console.log("returning 401, Not an admin");
       res.sendStatus(401);
@@ -81,6 +81,6 @@ const jwtAdminAuth = (req, res, next) => {
 };
 
 module.exports = {
-  jwtAuth,
-  jwtAdminAuth,
+  userOnly,
+  adminOnly,
 };

--- a/packages/backend/middlewares/auth.js
+++ b/packages/backend/middlewares/auth.js
@@ -54,11 +54,33 @@ const jwtAuth = (req, res, next) => {
   }
 
   req.address = addressToken;
+  req.isAdmin = tokenContents.claims.isAdmin;
 
-  console.log("success!");
   next();
+};
+
+/**
+ * Middleware to validate logged in admin requests.
+ *
+ * @param {Express.Request} req
+ * @param {Express.Response} res
+ * @param {Express.NextFunction} next
+ */
+const jwtAdminAuth = (req, res, next) => {
+  jwtAuth(req, res, () => {
+    // Added by jwtAuth
+    if (!req.isAdmin) {
+      console.log("returning 401, Not an admin");
+      res.sendStatus(401);
+      return;
+    }
+
+    next();
+  });
+
 };
 
 module.exports = {
   jwtAuth,
+  jwtAdminAuth,
 };

--- a/packages/react-app/src/App.jsx
+++ b/packages/react-app/src/App.jsx
@@ -282,6 +282,7 @@ function App() {
             setUserObject({});
           }}
           blockExplorer={blockExplorer}
+          isAdmin={userObject.isAdmin}
         />
         {faucetHint}
       </div>
@@ -308,19 +309,18 @@ function App() {
                 All Builders
               </Link>
             </Menu.Item>
-            {
-              // TODO: only display when the JWT indicates the user is a admin
-            }
-            <Menu.Item key="/challenge-review">
-              <Link
-                onClick={() => {
-                  setRoute("/challenge-review");
-                }}
-                to="/challenge-review"
-              >
-                Review Challenges
-              </Link>
-            </Menu.Item>
+            {userObject.isAdmin && (
+              <Menu.Item key="/challenge-review">
+                <Link
+                  onClick={() => {
+                    setRoute("/challenge-review");
+                  }}
+                  to="/challenge-review"
+                >
+                  Review Challenges
+                </Link>
+              </Menu.Item>
+            )}
           </Menu>
           <Switch>
             <Route exact path="/">
@@ -348,7 +348,7 @@ function App() {
             </Route>
             {/* ToDo: Protect this route on the frontend? */}
             <Route path="/challenge-review" exact>
-              <ChallengeReviewView serverUrl={serverUrl} />
+              <ChallengeReviewView serverUrl={serverUrl} token={userObject.token} address={address} />
             </Route>
             <Route path="/jwt-test">
               <JwtTest serverUrl={serverUrl} token={userObject.token} userProvider={userProvider} />

--- a/packages/react-app/src/components/Account.jsx
+++ b/packages/react-app/src/components/Account.jsx
@@ -1,9 +1,9 @@
 import React from "react";
-import { Button } from "antd";
+import { Badge, Button, Space } from "antd";
+import { useThemeSwitcher } from "react-css-theme-switcher";
 import Address from "./Address";
 import Balance from "./Balance";
 import Wallet from "./Wallet";
-import { useThemeSwitcher } from "react-css-theme-switcher";
 
 /*
   ~ What it does? ~
@@ -52,6 +52,7 @@ export default function Account({
   loadWeb3Modal,
   logoutOfWeb3Modal,
   blockExplorer,
+  isAdmin,
 }) {
   const modalButtons = [];
   if (web3Modal) {
@@ -77,7 +78,7 @@ export default function Account({
           type={minimized ? "default" : "primary"}
           onClick={loadWeb3Modal}
         >
-          {connectText?connectText:"connect"}
+          {connectText || "connect"}
         </Button>,
       );
     }
@@ -88,16 +89,27 @@ export default function Account({
   const display = minimized ? (
     ""
   ) : (
-    <span>
-      {address ? <Address address={address} ensProvider={mainnetProvider} blockExplorer={blockExplorer} /> : "Connecting..."}
+    <Space>
+      {isAdmin && <Badge count="admin" />}
+      {address ? (
+        <Address address={address} ensProvider={mainnetProvider} blockExplorer={blockExplorer} />
+      ) : (
+        "Connecting..."
+      )}
       <Balance address={address} provider={localProvider} price={price} />
-      <Wallet address={address} provider={userProvider} ensProvider={mainnetProvider} price={price} color={currentTheme == "light" ? "#1890ff" : "#2caad9"} />
-    </span>
+      <Wallet
+        address={address}
+        provider={userProvider}
+        ensProvider={mainnetProvider}
+        price={price}
+        color={currentTheme === "light" ? "#1890ff" : "#2caad9"}
+      />
+    </Space>
   );
 
   return (
     <div>
-      {onlyShowButton?"":display}
+      {onlyShowButton ? "" : display}
       {modalButtons}
     </div>
   );

--- a/packages/react-app/src/components/ChallengeSubmission.jsx
+++ b/packages/react-app/src/components/ChallengeSubmission.jsx
@@ -7,7 +7,7 @@ const { Text, Title } = Typography;
 
 const serverPath = "challenges";
 
-export default function ChallengeSubmission({ challenge, serverUrl, address }) {
+export default function ChallengeSubmission({ challenge, serverUrl, address, token }) {
   const { challengeId } = useParams();
   const [isSubmitting, setIsSubmitting] = useState(false);
 
@@ -16,13 +16,20 @@ export default function ChallengeSubmission({ challenge, serverUrl, address }) {
     setIsSubmitting(true);
 
     try {
-      await axios.post(serverUrl + serverPath, {
-        challengeId,
-        deployedUrl,
-        branchUrl,
-        // ToDo. Wont need this after JWT is implemented.
-        address,
-      });
+      await axios.post(
+        serverUrl + serverPath,
+        {
+          challengeId,
+          deployedUrl,
+          branchUrl,
+        },
+        {
+          headers: {
+            authorization: `token ${token}`,
+            address,
+          },
+        },
+      );
     } catch (error) {
       notification.error({
         message: "Submission Error. Please try again.",

--- a/packages/react-app/src/views/ChallengeDetailView.jsx
+++ b/packages/react-app/src/views/ChallengeDetailView.jsx
@@ -30,7 +30,7 @@ export default function ChallengeDetailView({ userObject, serverUrl, address }) 
         <AntdLink href={challenge.url} target="_blank">
           Link to challenge
         </AntdLink>
-        <ChallengeSubmission challenge={challenge} serverUrl={serverUrl} address={address} />
+        <ChallengeSubmission challenge={challenge} serverUrl={serverUrl} address={address} token={userObject.token} />
       </Space>
     </div>
   );

--- a/packages/react-app/src/views/ChallengeReviewView.jsx
+++ b/packages/react-app/src/views/ChallengeReviewView.jsx
@@ -2,14 +2,20 @@ import React, { useEffect } from "react";
 import axios from "axios";
 import ChallengeReviewList from "../components/ChallengeReviewList";
 
-export default function ChallengeReviewView({ serverUrl }) {
+export default function ChallengeReviewView({ serverUrl, token, address }) {
   const [challenges, setChallenges] = React.useState([]);
   const [isLoading, setIsLoading] = React.useState(true);
 
   async function fetchSubmittedChallenges() {
     setIsLoading(true);
-    console.log("getting challenges");
-    const fetchedChallenges = await axios.get(serverUrl + `challenges`, { params: { status: "SUBMITTED" } });
+    console.log("getting challenges", address);
+    const fetchedChallenges = await axios.get(serverUrl + `challenges`, {
+      params: { status: "SUBMITTED" },
+      headers: {
+        authorization: `token ${token}`,
+        address,
+      },
+    });
     setChallenges(fetchedChallenges.data);
     console.log(fetchedChallenges.data);
     setIsLoading(false);
@@ -17,21 +23,39 @@ export default function ChallengeReviewView({ serverUrl }) {
 
   useEffect(() => {
     fetchSubmittedChallenges();
-  }, [serverUrl]);
+  }, [serverUrl, address]);
 
   async function handleApprove(userAddress, challengeId, comment) {
     console.log(`approve ${challengeId} for ${userAddress} with comment ${comment}`);
-    await axios.patch(serverUrl + `challenges`, {
-      params: { userAddress, challengeId, comment, newStatus: "ACCEPTED" },
-    });
+    await axios.patch(
+      serverUrl + `challenges`,
+      {
+        params: { userAddress, challengeId, comment, newStatus: "ACCEPTED" },
+      },
+      {
+        headers: {
+          authorization: `token ${token}`,
+          address,
+        },
+      },
+    );
     fetchSubmittedChallenges();
   }
 
   async function handleReject(userAddress, challengeId, comment) {
     console.log(`reject ${challengeId} for ${userAddress} with comment ${comment}`);
-    await axios.patch(serverUrl + `challenges`, {
-      params: { userAddress, challengeId, comment, newStatus: "REJECTED" },
-    });
+    await axios.patch(
+      serverUrl + `challenges`,
+      {
+        params: { userAddress, challengeId, comment, newStatus: "REJECTED" },
+      },
+      {
+        headers: {
+          authorization: `token ${token}`,
+          address,
+        },
+      },
+    );
     fetchSubmittedChallenges();
   }
 

--- a/packages/react-app/src/views/JwtTest.jsx
+++ b/packages/react-app/src/views/JwtTest.jsx
@@ -32,6 +32,30 @@ const JwtTest = ({ serverUrl, token, userProvider }) => {
           <br />
           <span>Should fail if you signed with one account, and then switched accounts</span>
         </div>
+        <div>
+          <button
+            style={{ marginTop: 20 }}
+            type="button"
+            onClick={async () => {
+              try {
+                const response = await axios.get(`${serverUrl}auth-jwt-admin-restricted`, {
+                  headers: {
+                    authorization: `token ${token}`,
+                    address,
+                  },
+                });
+                console.log(response);
+              } catch (error) {
+                console.log(error);
+              }
+            }}
+          >
+            This sends valid JWT (to an Admin route)
+          </button>
+          <br />
+          <span>Should fail if you signed with one account, and then switched accounts.</span>
+          <span>Should fail if you are signed in but you are not an admin.</span>
+        </div>
         <button
           style={{ marginTop: 20 }}
           type="button"


### PR DESCRIPTION
Fixes #34 

To be an admin, just add a `isAdmin = true` (boolean value) property into your user's document in Firebase.

In this PR:

- Show an "admin" badge next to your address
- Remove link to challenge review for non-admins
- Create `jwtAdminAuth` middleware
- Protect all the routes with the corresponding auth middleware. Besides the sign route, I left out the builders & builders/:address routes (But maybe we want to protect them as well)
- Tweak all the axios calls to include the headers.
-  Create an admin auth test in `/jwt-test`
- Update the `set` call on database saves to `update`. `set` overrides the whole document.