### PR TITLE
Fix textarea bug

### DIFF
--- a/packages/react-app/src/components/ChallengeReviewList.jsx
+++ b/packages/react-app/src/components/ChallengeReviewList.jsx
@@ -27,7 +27,6 @@ export default function ChallengeReviewList({ challengeSubmissions, isLoading, a
                   currentCommentMap[challenge.userAddress + challenge.id] = e.target.value;
                   setCommentMap(currentCommentMap);
                 }}
-                value={commentMap[challenge.userAddress + challenge.id]}
                 placeholder="Comment for builder"
                 style={{ marginBottom: 10 }}
                 rows={2}

--- a/packages/react-app/src/components/ChallengeReviewList.jsx
+++ b/packages/react-app/src/components/ChallengeReviewList.jsx
@@ -11,6 +11,7 @@ export default function ChallengeReviewList({ challengeSubmissions, isLoading, a
       dataSource={challengeSubmissions}
       renderItem={challenge => (
         <List.Item
+          key={challenge.userAddress + challenge.id}
           actions={[
             <Button type="link" href={challenge.branchUrl} target="_blank">
               Code


### PR DESCRIPTION
Fix #54 

When the component was initially rendering:

```js
value={commentMap[challenge.userAddress + challenge.id]}
```

this was undefined, so it didn't attach the prop to `<Input.Textarea>`. When a new mainnnet block occurred, this component was re-rendered causing the value to be fixed to whatever we had on the state, causing the input to "freeze".

Controlled components in antd work in a different way. We could use antd's `<Form>` and `<Form.Item>` to use controlled components, but for now I've just remove the `value` prop.
