### PR TITLE
Show spinner while loading user info

### DIFF
--- a/packages/react-app/src/App.jsx
+++ b/packages/react-app/src/App.jsx
@@ -132,7 +132,7 @@ function App() {
     }
   }, [loadWeb3Modal]);
 
-  const [userRole, setUserRole] = useState(USER_ROLES.anonymous);
+  const [userRole, setUserRole] = useState(null);
 
   useEffect(() => {
     async function fetchUserData() {

--- a/packages/react-app/src/components/Account.jsx
+++ b/packages/react-app/src/components/Account.jsx
@@ -11,6 +11,7 @@ import {
   PopoverTrigger,
   PopoverContent,
   PopoverBody,
+  Spinner,
   Text,
   Tooltip,
   useToast,
@@ -76,6 +77,10 @@ export default function Account({
   const openPopover = () => setIsPopoverOpen(true);
   const closePopover = () => setIsPopoverOpen(false);
   const { primaryFontColor, secondaryFontColor, dividerColor } = useCustomColorModes();
+
+  if (!userRole && isWalletConnected) {
+    return <Spinner />;
+  }
 
   const hasEns = ens !== shortAddress;
   const isAdmin = userRole === USER_ROLES.admin;

--- a/packages/react-app/src/components/Header.jsx
+++ b/packages/react-app/src/components/Header.jsx
@@ -97,7 +97,7 @@ export default function Header({
           loadWeb3Modal={loadWeb3Modal}
           logoutOfWeb3Modal={() => {
             logoutOfWeb3Modal();
-            setUserRole(USER_ROLES.anonymous);
+            setUserRole(null);
           }}
           setUserRole={setUserRole}
           userProvider={userProvider}


### PR DESCRIPTION
Fixes #104 

- **Null role:** Users (visitors) without a connected wallet shouldn't have a **role**. 
- **Anon role**: Users with their wallet connected and not in the database

Making this concept change, made it easier to fix this.

The "Connect wallet" button still flashes until the **injectedProvider** kicks in. If we really want to fix that one, I think we'd need to use a timer.