### PR TITLE
Branch to contract url

### DIFF
--- a/packages/backend/index.js
+++ b/packages/backend/index.js
@@ -97,9 +97,9 @@ app.get("/user", async (request, response) => {
 });
 
 app.post("/challenges", withAddress, async (request, response) => {
-  const { challengeId, deployedUrl, branchUrl, signature } = request.body;
+  const { challengeId, deployedUrl, contractUrl, signature } = request.body;
   const address = request.address;
-  console.log("POST /challenges: ", address, challengeId, deployedUrl, branchUrl);
+  console.log("POST /challenges: ", address, challengeId, deployedUrl, contractUrl);
 
   const verifyOptions = {
     messageId: "challengeSubmit",
@@ -123,14 +123,14 @@ app.post("/challenges", withAddress, async (request, response) => {
   // ToDo. Extract challenge status (ENUM)
   existingChallenges[challengeId] = {
     status: "SUBMITTED",
-    branchUrl,
+    contractUrl,
     deployedUrl,
   };
   const eventPayload = {
     userAddress: address,
     challengeId,
     deployedUrl,
-    branchUrl,
+    contractUrl,
   };
   const event = createEvent(EVENT_TYPES.CHALLENGE_SUBMIT, eventPayload, signature);
   db.createEvent(event); // INFO: async, no await here

--- a/packages/backend/local_database/seed.json
+++ b/packages/backend/local_database/seed.json
@@ -15,13 +15,13 @@
       "challenges": {
         "simple-nft-example": {
           "status": "ACCEPTED",
-          "branchUrl": "https://github.com/austintgriffith/scaffold-eth/tree/simple-nft-example",
+          "contractUrl": "https://etherscan.io/address/0xde30da39c46104798bb5aa3fe8b9e0e1f348163f",
           "deployedUrl": "https://github.com/austintgriffith/scaffold-eth/tree/simple-nft-example_v1",
           "reviewComment": "Nice work!"
         },
         "decentralized-staking": {
           "status": "REJECTED",
-          "branchUrl": "https://github.com/austintgriffith/scaffold-eth/tree/challenge-1-decentralized-staking",
+          "contractUrl": "https://etherscan.io/address/0xde30da39c46104798bb5aa3fe8b9e0e1f348163f",
           "deployedUrl": "https://github.com/austintgriffith/scaffold-eth/tree/challenge-1-decentralized-staking_v1",
           "reviewComment": "It throws an error when opening the app."
         }
@@ -33,7 +33,7 @@
       "challenges": {
         "simple-nft-example": {
           "status": "ACCEPTED",
-          "branchUrl": "https://github.com/austintgriffith/scaffold-eth/tree/simple-nft-example",
+          "contractUrl": "https://etherscan.io/address/0xde30da39c46104798bb5aa3fe8b9e0e1f348163f",
           "deployedUrl": "https://github.com/austintgriffith/scaffold-eth/tree/simple-nft-example_v2",
           "reviewComment": "Now it's working great!"
         }
@@ -304,7 +304,7 @@
         "userAddress": "0x70997970C51812dc3A010C7d01b50e0d17dc79C8",
         "challengeId": "simple-nft-example",
         "deployedUrl": "https://github.com/austintgriffith/scaffold-eth/tree/simple-nft-example_v1",
-        "branchUrl": "https://github.com/austintgriffith/scaffold-eth/tree/simple-nft-example"
+        "contractUrl": "https://etherscan.io/address/0xde30da39c46104798bb5aa3fe8b9e0e1f348163f"
       }
     },
     {
@@ -315,7 +315,7 @@
         "userAddress": "0x3C44CdDdB6a900fa2b585dd299e03d12FA4293BC",
         "challengeId": "simple-nft-example",
         "deployedUrl": "https://github.com/austintgriffith/scaffold-eth/tree/simple-nft-example_v1",
-        "branchUrl": "https://github.com/austintgriffith/scaffold-eth/tree/simple-nft-example"
+        "contractUrl": "https://etherscan.io/address/0xde30da39c46104798bb5aa3fe8b9e0e1f348163f"
       }
     },
     {
@@ -338,7 +338,7 @@
         "userAddress": "0x3C44CdDdB6a900fa2b585dd299e03d12FA4293BC",
         "challengeId": "decentralized-staking",
         "deployedUrl": "https://github.com/austintgriffith/scaffold-eth/tree/challenge-1-decentralized-staking_v1",
-        "branchUrl": "https://github.com/austintgriffith/scaffold-eth/tree/challenge-1-decentralized-staking"
+        "contractUrl": "https://etherscan.io/address/0xde30da39c46104798bb5aa3fe8b9e0e1f348163f"
       }
     },
     {
@@ -369,7 +369,7 @@
         "userAddress": "0x90F79bf6EB2c4f870365E785982E1f101E93b906",
         "challengeId": "simple-nft-example",
         "deployedUrl": "https://github.com/austintgriffith/scaffold-eth/tree/simple-nft-example_v1",
-        "branchUrl": "https://github.com/austintgriffith/scaffold-eth/tree/simple-nft-example"
+        "contractUrl": "https://etherscan.io/address/0xde30da39c46104798bb5aa3fe8b9e0e1f348163f"
       }
     },
     {
@@ -392,7 +392,7 @@
         "userAddress": "0x90F79bf6EB2c4f870365E785982E1f101E93b906",
         "challengeId": "simple-nft-example",
         "deployedUrl": "https://github.com/austintgriffith/scaffold-eth/tree/simple-nft-example_v2",
-        "branchUrl": "https://github.com/austintgriffith/scaffold-eth/tree/simple-nft-example"
+        "contractUrl": "https://etherscan.io/address/0xde30da39c46104798bb5aa3fe8b9e0e1f348163f"
       }
     },
     {

--- a/packages/backend/services/dbLocal.test.js
+++ b/packages/backend/services/dbLocal.test.js
@@ -26,7 +26,7 @@ const dummyPayloadsByType = {
     userAddress: dummyAddressA,
     challengeId: dummyChallengeIdA,
     deployedUrl: "https://moonshotcollective.space/",
-    branchUrl: "https://github.com/moonshotcollective/scaffold-directory",
+    contractUrl: "https://etherscan.io/token/0xde30da39c46104798bb5aa3fe8b9e0e1f348163f",
   },
   [EVENT_TYPES.CHALLENGE_REVIEW]: {
     reviewAction: "ACCEPTED",

--- a/packages/react-app/src/components/ChallengeReviewRow.jsx
+++ b/packages/react-app/src/components/ChallengeReviewRow.jsx
@@ -24,8 +24,14 @@ export default function ChallengeReviewRow({ challenge, isLoading, approveClick,
         </Link>
       </Td>
       <Td>
-        <Link href={challenge.branchUrl} color="teal.500" target="_blank" rel="noopener noreferrer">
-          Code
+        <Link
+          // Legacy branchUrl
+          href={challenge.contractUrl || challenge.branchUrl}
+          color="teal.500"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          Contract
         </Link>
       </Td>
       <Td>

--- a/packages/react-app/src/components/ChallengeSubmission.jsx
+++ b/packages/react-app/src/components/ChallengeSubmission.jsx
@@ -1,7 +1,8 @@
 import React, { useState } from "react";
 import axios from "axios";
 import { useHistory, useParams } from "react-router-dom";
-import { Button, Heading, FormControl, FormLabel, Input, Text, useToast } from "@chakra-ui/react";
+import { Button, Heading, FormControl, FormLabel, Input, Text, Tooltip, useToast } from "@chakra-ui/react";
+import { QuestionOutlineIcon } from "@chakra-ui/icons";
 
 const serverPath = "/challenges";
 
@@ -112,7 +113,12 @@ export default function ChallengeSubmission({ challenge, serverUrl, address, use
       ) : (
         <form name="basic" autoComplete="off">
           <FormControl id="deployedUrl" isRequired>
-            <FormLabel>Deployed URL</FormLabel>
+            <FormLabel>
+              Deployed URL{" "}
+              <Tooltip label="Your deployed challenge URL on surge / s3 / ipfs ">
+                <QuestionOutlineIcon ml="2px" />
+              </Tooltip>
+            </FormLabel>
             <Input
               type="text"
               name="deployedUrl"
@@ -124,7 +130,12 @@ export default function ChallengeSubmission({ challenge, serverUrl, address, use
           </FormControl>
 
           <FormControl id="contractUrl" isRequired mt={4}>
-            <FormLabel>Etherscan Contract URL</FormLabel>
+            <FormLabel>
+              Etherscan Contract URL{" "}
+              <Tooltip label="Your verified contract URL on Etherscan">
+                <QuestionOutlineIcon ml="2px" />
+              </Tooltip>
+            </FormLabel>
             <Input
               type="text"
               name="contractUrl"

--- a/packages/react-app/src/components/ChallengeSubmission.jsx
+++ b/packages/react-app/src/components/ChallengeSubmission.jsx
@@ -12,10 +12,10 @@ export default function ChallengeSubmission({ challenge, serverUrl, address, use
   const toast = useToast({ position: "top", isClosable: true });
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [deployedUrl, setDeployedUrl] = useState("");
-  const [branchUrl, setBranchUrl] = useState("");
+  const [contractUrl, setContractUrl] = useState("");
 
   const onFinish = async () => {
-    if (!deployedUrl || !branchUrl) {
+    if (!deployedUrl || !contractUrl) {
       toast({
         status: "error",
         description: "Can't get the message to sign. Please try again",
@@ -64,7 +64,7 @@ export default function ChallengeSubmission({ challenge, serverUrl, address, use
         {
           challengeId,
           deployedUrl,
-          branchUrl,
+          contractUrl,
           signature,
         },
         {
@@ -93,14 +93,22 @@ export default function ChallengeSubmission({ challenge, serverUrl, address, use
   };
 
   if (!address) {
-    return <Text color="orange.400" className="warning" align="center">Connect your wallet to submit this Challenge.</Text>;
+    return (
+      <Text color="orange.400" className="warning" align="center">
+        Connect your wallet to submit this Challenge.
+      </Text>
+    );
   }
 
   return (
     <div>
-      <Heading as="h2" size="md" mb={4}>{challenge.label}</Heading>
+      <Heading as="h2" size="md" mb={4}>
+        {challenge.label}
+      </Heading>
       {challenge.isDisabled ? (
-        <Text color="orange.400" className="warning">This challenge is disabled.</Text>
+        <Text color="orange.400" className="warning">
+          This challenge is disabled.
+        </Text>
       ) : (
         <form name="basic" autoComplete="off">
           <FormControl id="deployedUrl" isRequired>
@@ -115,14 +123,14 @@ export default function ChallengeSubmission({ challenge, serverUrl, address, use
             />
           </FormControl>
 
-          <FormControl id="branchUrl" isRequired mt={4}>
-            <FormLabel>Branch URL</FormLabel>
+          <FormControl id="contractUrl" isRequired mt={4}>
+            <FormLabel>Etherscan Contract URL</FormLabel>
             <Input
               type="text"
-              name="branchUrl"
-              value={branchUrl}
+              name="contractUrl"
+              value={contractUrl}
               onChange={e => {
-                setBranchUrl(e.target.value);
+                setContractUrl(e.target.value);
               }}
             />
           </FormControl>

--- a/packages/react-app/src/data/challenges/decentralized-staking.md
+++ b/packages/react-app/src/data/challenges/decentralized-staking.md
@@ -8,7 +8,6 @@
 
 > 🏆 The final **deliverable** is deploying a decentralized application to a public blockchain and then `yarn build` and `yarn surge` your app to a public webserver.
 
-
 🧫 Everything starts by ✏️ Editing `Staker.sol` in `packages/hardhat/contracts`
 
 ---
@@ -73,9 +72,9 @@ uint256 public constant threshold = 1 ether;
 
 > ⚙️  Think of your smart contract like a *state machine*. First, there is a **stake** period. Then, if you have gathered the `threshold` worth of ETH, there is a **success** state. Or, we go into a **withdraw** state to let users withdraw their funds.
 
-Set a `deadline` of ```now + 30 seconds```
+Set a `deadline` of ```block.timestamp + 30 seconds```
 ```solidity
-uint256 public deadline = now + 30 seconds;
+uint256 public deadline = block.timestamp + 30 seconds;
 ```
 
 👨‍🏫 Smart contracts can't execute automatically, you always need to have a transaction execute to change state. Because of this, you will need to have an `execute()` function that *anyone* can call, just once, after the `deadline` has expired.
@@ -90,7 +89,7 @@ If the balance is less than the `threshold`, you want to set a `openForWithdraw`
 
 > 👩‍💻 Create a `timeLeft()` function including ```public view returns (uint256)``` that returns how much time is left.
 
-⚠️ Be careful! if `now >= deadline` you want to ```return 0;```
+⚠️ Be careful! if `block.timestamp >= deadline` you want to ```return 0;```
 
 ⏳ The time will only update if a transaction occurs. You can see the time update by getting funds from the faucet just to trigger a new block.
 
@@ -110,6 +109,8 @@ If the balance is less than the `threshold`, you want to set a `openForWithdraw`
 🎀 To improve the user experience, set your contract up so it accepts ETH sent to it and calls `stake()`. You will use what is called the `receive()` function.
 
 > Use the [receive()](https://docs.soliditylang.org/en/v0.8.9/contracts.html?highlight=receive#receive-ether-function) function in solidity to "catch" ETH sent to the contract and call `stake()` to update `balances`.
+
+---
 
 #### 🥅 Goals
 - [ ] If you send ETH directly to the contract address does it update your `balance`?
@@ -141,6 +142,17 @@ If the balance is less than the `threshold`, you want to set a `openForWithdraw`
 
 >  🚀 Run `yarn deploy` to deploy your smart contract to a public network (selected in hardhat.config.js)
 
+---
+
+## 🔍 Etherscan Contract Verification
+> Get a free [Etherscan API key](https://etherscan.io/apis) and update your hardhat.config.js file with it.
+
+![Screen Shot 2021-11-24 at 9 13 40 AM](https://user-images.githubusercontent.com/9419140/143254420-1916d419-7477-4eec-b201-94166174d8c3.png)
+
+> You will need to uncomment the verify task in the deploy script to verify your contract(s). We will use your verified contract to check your work 👀
+
+![Screen Shot 2021-11-24 at 9 25 44 AM](https://user-images.githubusercontent.com/9419140/143256354-29675a6d-5e3e-421b-800f-7c35ced5e6f4.png)
+
  ---
 
 ### Checkpoint 6: 🎚 Frontend 🧘‍♀️
@@ -158,3 +170,9 @@ If the balance is less than the `threshold`, you want to set a `openForWithdraw`
 💽 Upload your app to surge with `yarn surge` (you could also `yarn s3` or maybe even `yarn ipfs`?)
 
 🚔 Traffic to your url might break the [Infura](https://infura.io/) rate limit, edit your key: `constants.js` in `packages/ract-app/src`.
+
+---
+
+> 👩‍🔬 Need a longer form tutorial to guide your coding? [Try this one!](https://github.com/austintgriffith/scaffold-eth/tree/staking-app-tutorial)
+
+> 💬 Problems, questions, comments on the stack? Post them to the [🏗 scaffold-eth developers chat](https://t.me/joinchat/F7nCRK3kI93PoCOk)

--- a/packages/react-app/src/data/challenges/decentralized-staking.ts.md
+++ b/packages/react-app/src/data/challenges/decentralized-staking.ts.md
@@ -8,7 +8,6 @@
 
 > 🏆 The final **deliverable** is deploying a decentralized application to a public blockchain and then `yarn build` and `yarn surge` your app to a public webserver.
 
-
 🧫 Everything starts by ✏️ Editing `Staker.sol` in `packages/hardhat/contracts`
 
 ---
@@ -73,9 +72,9 @@ uint256 public constant threshold = 1 ether;
 
 > ⚙️  Think of your smart contract like a *state machine*. First, there is a **stake** period. Then, if you have gathered the `threshold` worth of ETH, there is a **success** state. Or, we go into a **withdraw** state to let users withdraw their funds.
 
-Set a `deadline` of ```now + 30 seconds```
+Set a `deadline` of ```block.timestamp + 30 seconds```
 ```solidity
-uint256 public deadline = now + 30 seconds;
+uint256 public deadline = block.timestamp + 30 seconds;
 ```
 
 👨‍🏫 Smart contracts can't execute automatically, you always need to have a transaction execute to change state. Because of this, you will need to have an `execute()` function that *anyone* can call, just once, after the `deadline` has expired.
@@ -90,7 +89,7 @@ If the balance is less than the `threshold`, you want to set a `openForWithdraw`
 
 > 👩‍💻 Create a `timeLeft()` function including ```public view returns (uint256)``` that returns how much time is left.
 
-⚠️ Be careful! if `now >= deadline` you want to ```return 0;```
+⚠️ Be careful! if `block.timestamp >= deadline` you want to ```return 0;```
 
 ⏳ The time will only update if a transaction occurs. You can see the time update by getting funds from the faucet just to trigger a new block.
 
@@ -110,6 +109,8 @@ If the balance is less than the `threshold`, you want to set a `openForWithdraw`
 🎀 To improve the user experience, set your contract up so it accepts ETH sent to it and calls `stake()`. You will use what is called the `receive()` function.
 
 > Use the [receive()](https://docs.soliditylang.org/en/v0.8.9/contracts.html?highlight=receive#receive-ether-function) function in solidity to "catch" ETH sent to the contract and call `stake()` to update `balances`.
+
+---
 
 #### 🥅 Goals
 - [ ] If you send ETH directly to the contract address does it update your `balance`?
@@ -141,6 +142,17 @@ If the balance is less than the `threshold`, you want to set a `openForWithdraw`
 
 >  🚀 Run `yarn deploy` to deploy your smart contract to a public network (selected in hardhat.config.js)
 
+---
+
+## 🔍 Etherscan Contract Verification
+> Get a free [Etherscan API key](https://etherscan.io/apis) and update your hardhat.config.js file with it.
+
+![Screen Shot 2021-11-24 at 9 13 40 AM](https://user-images.githubusercontent.com/9419140/143254420-1916d419-7477-4eec-b201-94166174d8c3.png)
+
+> You will need to uncomment the verify task in the deploy script to verify your contract(s). We will use your verified contract to check your work 👀
+
+![Screen Shot 2021-11-24 at 9 25 44 AM](https://user-images.githubusercontent.com/9419140/143256354-29675a6d-5e3e-421b-800f-7c35ced5e6f4.png)
+
  ---
 
 ### Checkpoint 6: 🎚 Frontend 🧘‍♀️
@@ -158,3 +170,9 @@ If the balance is less than the `threshold`, you want to set a `openForWithdraw`
 💽 Upload your app to surge with `yarn surge` (you could also `yarn s3` or maybe even `yarn ipfs`?)
 
 🚔 Traffic to your url might break the [Infura](https://infura.io/) rate limit, edit your key: `constants.js` in `packages/ract-app/src`.
+
+---
+
+> 👩‍🔬 Need a longer form tutorial to guide your coding? [Try this one!](https://github.com/austintgriffith/scaffold-eth/tree/staking-app-tutorial)
+
+> 💬 Problems, questions, comments on the stack? Post them to the [🏗 scaffold-eth developers chat](https://t.me/joinchat/F7nCRK3kI93PoCOk)

--- a/packages/react-app/src/data/challenges/simple-nft-example.md
+++ b/packages/react-app/src/data/challenges/simple-nft-example.md
@@ -119,7 +119,7 @@ yarn mint
 
 ⛽️ Use a faucet like [faucet.paradigm.xyz](https://faucet.paradigm.xyz/) to fund your **deployer address**.
 
-> ⚔️ **Side Quest:** Keep a 🧑‍🎤 punkwallet.io on your phone's home screen and keep it loaded with testnet eth. 🧙‍♂️ You'll look like a wizard when you can fund your **deployer address** from your phone in seconds.
+> ⚔️ **Side Quest:** Keep a 🧑‍🎤 [punkwallet.io](https://punkwallet.io/) on your phone's home screen and keep it loaded with testnet eth. 🧙‍♂️ You'll look like a wizard when you can fund your **deployer address** from your phone in seconds.
 
 🚀 Deploy your NFT smart contract:
 
@@ -167,11 +167,6 @@ yarn surge
 ---
 
 # Checkpoint 5: 💪 Flex!
-
-> 🎖 Show off your app by pasting the surge url in the [Challenge 0 telegram channel](https://t.me/joinchat/Y2vqXZZ_pEFhMGMx)
-
----
-
 👩‍❤️‍👨 Share your public url with a friend and ask them for their address to send them a collectible :)
 
 ![nft15](https://user-images.githubusercontent.com/526558/124387205-00c3fb80-dcb4-11eb-9e2f-29585e323037.gif)
@@ -185,14 +180,23 @@ yarn surge
 
 (It can take a while before they show up, but here is an example:)
 https://testnets.opensea.io/assets/0xc2839329166d3d004aaedb94dde4173651babccf/1
+
 ## 🔍 Etherscan Contract Verification
-> run yarn flatten > flat.txt (You will need to clean up extra junk at the top and bottom of flat.txt. Sorry, rookie stuff here.)
+> Get a free [Etherscan API key](https://etherscan.io/apis) and update your hardhat.config.js file with it.
 
-> copy the contents of flat.txt to the block explorer and select compiler v0.6.7 and Yes to Optimization (200 runs if anyone asks)
+![Screen Shot 2021-11-24 at 9 13 40 AM](https://user-images.githubusercontent.com/9419140/143254420-1916d419-7477-4eec-b201-94166174d8c3.png)
 
-![nft12](https://user-images.githubusercontent.com/526558/124387153-c8bcb880-dcb3-11eb-8191-e53f87129b88.png)
+> You will need to uncomment the verify task in the deploy script to verify your contract(s). We will use your verified contract to check your work 👀
+
+![Screen Shot 2021-11-24 at 9 07 12 AM](https://user-images.githubusercontent.com/9419140/143253497-8f04b35d-89e2-4a96-b532-a8e48c99e482.png)
 
 ## 🔶 Infura
 > You will need to get a key from infura.io and paste it into constants.js in packages/react-app/src:
 
 ![nft13](https://user-images.githubusercontent.com/526558/124387174-d83c0180-dcb3-11eb-989e-d58ba15d26db.png)
+
+---
+
+> 🏰 Buidl Guidl Discord Server [Join Here](https://discord.gg/ZnFs36fbbU)
+
+> 💬 Problems, questions, comments on the stack? Post them to the [🏗 scaffold-eth developers chat](https://t.me/joinchat/F7nCRK3kI93PoCOk)

--- a/packages/react-app/src/data/challenges/simple-nft-example.ts.md
+++ b/packages/react-app/src/data/challenges/simple-nft-example.ts.md
@@ -1,4 +1,4 @@
-## TS:  🚩 Challenge 0: 🎟 Simple NFT Example 🤓
+## TS: 🚩 Challenge 0: 🎟 Simple NFT Example 🤓
 
 🎫 Create a simple NFT to learn basics of 🏗 scaffold-eth. You'll use [👷‍♀️ HardHat](https://hardhat.org/getting-started/) to compile and deploy smart contracts. Then, you'll use a template React app full of important Ethereum components and hooks. Finally, you'll deploy an NFT to a public network to share with friends! 🚀
 
@@ -119,7 +119,7 @@ yarn mint
 
 ⛽️ Use a faucet like [faucet.paradigm.xyz](https://faucet.paradigm.xyz/) to fund your **deployer address**.
 
-> ⚔️ **Side Quest:** Keep a 🧑‍🎤 punkwallet.io on your phone's home screen and keep it loaded with testnet eth. 🧙‍♂️ You'll look like a wizard when you can fund your **deployer address** from your phone in seconds.
+> ⚔️ **Side Quest:** Keep a 🧑‍🎤 [punkwallet.io](https://punkwallet.io/) on your phone's home screen and keep it loaded with testnet eth. 🧙‍♂️ You'll look like a wizard when you can fund your **deployer address** from your phone in seconds.
 
 🚀 Deploy your NFT smart contract:
 
@@ -167,11 +167,6 @@ yarn surge
 ---
 
 # Checkpoint 5: 💪 Flex!
-
-> 🎖 Show off your app by pasting the surge url in the [Challenge 0 telegram channel](https://t.me/joinchat/Y2vqXZZ_pEFhMGMx)
-
----
-
 👩‍❤️‍👨 Share your public url with a friend and ask them for their address to send them a collectible :)
 
 ![nft15](https://user-images.githubusercontent.com/526558/124387205-00c3fb80-dcb4-11eb-9e2f-29585e323037.gif)
@@ -185,14 +180,23 @@ yarn surge
 
 (It can take a while before they show up, but here is an example:)
 https://testnets.opensea.io/assets/0xc2839329166d3d004aaedb94dde4173651babccf/1
+
 ## 🔍 Etherscan Contract Verification
-> run yarn flatten > flat.txt (You will need to clean up extra junk at the top and bottom of flat.txt. Sorry, rookie stuff here.)
+> Get a free [Etherscan API key](https://etherscan.io/apis) and update your hardhat.config.js file with it.
 
-> copy the contents of flat.txt to the block explorer and select compiler v0.6.7 and Yes to Optimization (200 runs if anyone asks)
+![Screen Shot 2021-11-24 at 9 13 40 AM](https://user-images.githubusercontent.com/9419140/143254420-1916d419-7477-4eec-b201-94166174d8c3.png)
 
-![nft12](https://user-images.githubusercontent.com/526558/124387153-c8bcb880-dcb3-11eb-8191-e53f87129b88.png)
+> You will need to uncomment the verify task in the deploy script to verify your contract(s). We will use your verified contract to check your work 👀
+
+![Screen Shot 2021-11-24 at 9 07 12 AM](https://user-images.githubusercontent.com/9419140/143253497-8f04b35d-89e2-4a96-b532-a8e48c99e482.png)
 
 ## 🔶 Infura
 > You will need to get a key from infura.io and paste it into constants.js in packages/react-app/src:
 
 ![nft13](https://user-images.githubusercontent.com/526558/124387174-d83c0180-dcb3-11eb-989e-d58ba15d26db.png)
+
+---
+
+> 🏰 Buidl Guidl Discord Server [Join Here](https://discord.gg/ZnFs36fbbU)
+
+> 💬 Problems, questions, comments on the stack? Post them to the [🏗 scaffold-eth developers chat](https://t.me/joinchat/F7nCRK3kI93PoCOk)

--- a/packages/react-app/src/data/challenges/token-vendor.md
+++ b/packages/react-app/src/data/challenges/token-vendor.md
@@ -1,6 +1,5 @@
 ## 🚩 Challenge 2: 🏵 Token Vendor 🤖
 
-
 > 🤖 Smart contracts are kind of like "always on" *vending machines* that **anyone** can access. Let's make a decentralized, digital currency. Then, let's build an unstoppable vending machine that will buy and sell the currency. We'll learn about the "approve" pattern for ERC20s and how contract to contract interactions work.
 
 > 🏵 Create `YourToken.sol` smart contract that inherits the **ERC20** token standard from OpenZeppelin. Set your token to `_mint()` **1000** (\* 10 \*\* 18) tokens to the `msg.sender`. Then create a `Vendor.sol` contract that sells your token using a payable `buyTokens()` function.
@@ -175,3 +174,8 @@ at around line 258. The verify script is at the bottom of `00_deploy_your_token.
 
 🚔 Traffic to your url might break the [Infura](https://infura.io/) rate limit, edit your key: `constants.js` in `packages/ract-app/src`.
 
+---
+
+> 🏰 Buidl Guidl Discord Server [Join Here](https://discord.gg/ZnFs36fbbU)
+
+> 💬 Problems, questions, comments on the stack? Post them to the [🏗 scaffold-eth developers chat](https://t.me/joinchat/F7nCRK3kI93PoCOk)

--- a/packages/react-app/src/data/challenges/token-vendor.ts.md
+++ b/packages/react-app/src/data/challenges/token-vendor.ts.md
@@ -1,5 +1,4 @@
-## TS:  🚩 Challenge 2: 🏵 Token Vendor 🤖
-
+## TS: 🚩 Challenge 2: 🏵 Token Vendor 🤖
 
 > 🤖 Smart contracts are kind of like "always on" *vending machines* that **anyone** can access. Let's make a decentralized, digital currency. Then, let's build an unstoppable vending machine that will buy and sell the currency. We'll learn about the "approve" pattern for ERC20s and how contract to contract interactions work.
 
@@ -175,3 +174,8 @@ at around line 258. The verify script is at the bottom of `00_deploy_your_token.
 
 🚔 Traffic to your url might break the [Infura](https://infura.io/) rate limit, edit your key: `constants.js` in `packages/ract-app/src`.
 
+---
+
+> 🏰 Buidl Guidl Discord Server [Join Here](https://discord.gg/ZnFs36fbbU)
+
+> 💬 Problems, questions, comments on the stack? Post them to the [🏗 scaffold-eth developers chat](https://t.me/joinchat/F7nCRK3kI93PoCOk)

--- a/packages/react-app/src/views/BuilderProfileView.jsx
+++ b/packages/react-app/src/views/BuilderProfileView.jsx
@@ -115,7 +115,7 @@ export default function BuilderProfileView({ serverUrl, mainnetProvider, address
                 <Thead>
                   <Tr>
                     <Th w="full">Name</Th>
-                    <Th>Code</Th>
+                    <Th>Contract</Th>
                     <Th>Live Demo</Th>
                     <Th>Status</Th>
                     <Th>Date</Th>
@@ -136,7 +136,8 @@ export default function BuilderProfileView({ serverUrl, mainnetProvider, address
                         <Td>
                           {lastSubmission.status === CHALLENGE_SUBMISSION_STATUS.ACCEPTED ? (
                             <Link
-                              href={lastSubmission.branchUrl}
+                              // Legacy branchUrl
+                              href={lastSubmission.contractUrl || lastSubmission.branchUrl}
                               color="teal.500"
                               target="_blank"
                               rel="noopener noreferrer"

--- a/packages/react-app/src/views/SubmissionReviewView.jsx
+++ b/packages/react-app/src/views/SubmissionReviewView.jsx
@@ -203,79 +203,79 @@ export default function SubmissionReviewView({ userProvider }) {
       </Heading>
       <Box overflowX="auto">
         <Table>
-        <Thead>
-          <Tr>
-            <Th>Builder</Th>
-            <Th>Challenge</Th>
-            <Th>Code</Th>
-            <Th>Live demo</Th>
-            <Th>Comment</Th>
-            <Th>Actions</Th>
-          </Tr>
-        </Thead>
-        <Tbody>
-          {!challenges || challenges.length === 0 ? (
+          <Thead>
             <Tr>
-              <Td colSpan={6}>
-                <Text color={secondaryFontColor} textAlign="center" mb={4}>
-                  <Icon as={HeroIconInbox} w={6} h={6} color={secondaryFontColor} mt={6} mb={4} />
-                  <br />
-                  All challenges have been reviewed
-                </Text>
-              </Td>
+              <Th>Builder</Th>
+              <Th>Challenge</Th>
+              <Th>Contract</Th>
+              <Th>Live demo</Th>
+              <Th>Comment</Th>
+              <Th>Actions</Th>
             </Tr>
-          ) : (
-            challenges.map(challenge => (
-              <ChallengeReviewRow
-                key={`${challenge.userAddress}_${challenge.id}`}
-                challenge={challenge}
-                isLoading={isLoadingChallenges}
-                approveClick={handleSendChallengeReview("ACCEPTED")}
-                rejectClick={handleSendChallengeReview("REJECTED")}
-              />
-            ))
-          )}
-        </Tbody>
-      </Table>
+          </Thead>
+          <Tbody>
+            {!challenges || challenges.length === 0 ? (
+              <Tr>
+                <Td colSpan={6}>
+                  <Text color={secondaryFontColor} textAlign="center" mb={4}>
+                    <Icon as={HeroIconInbox} w={6} h={6} color={secondaryFontColor} mt={6} mb={4} />
+                    <br />
+                    All challenges have been reviewed
+                  </Text>
+                </Td>
+              </Tr>
+            ) : (
+              challenges.map(challenge => (
+                <ChallengeReviewRow
+                  key={`${challenge.userAddress}_${challenge.id}`}
+                  challenge={challenge}
+                  isLoading={isLoadingChallenges}
+                  approveClick={handleSendChallengeReview("ACCEPTED")}
+                  rejectClick={handleSendChallengeReview("REJECTED")}
+                />
+              ))
+            )}
+          </Tbody>
+        </Table>
       </Box>
       <Heading as="h2" size="lg" mt={6} mb={4}>
         Builds
       </Heading>
       <Box overflowX="auto">
         <Table mb={4}>
-        <Thead>
-          <Tr>
-            <Th>Builder</Th>
-            <Th>Build Name</Th>
-            <Th>Description</Th>
-            <Th>Branch URL</Th>
-            <Th>Actions</Th>
-          </Tr>
-        </Thead>
-        <Tbody>
-          {!draftBuilds || draftBuilds.length === 0 ? (
+          <Thead>
             <Tr>
-              <Td colSpan={5}>
-                <Text color={secondaryFontColor} textAlign="center" mb={4}>
-                  <Icon as={HeroIconInbox} w={6} h={6} color={secondaryFontColor} mt={6} mb={4} />
-                  <br />
-                  All builds have been reviewed
-                </Text>
-              </Td>
+              <Th>Builder</Th>
+              <Th>Build Name</Th>
+              <Th>Description</Th>
+              <Th>Branch URL</Th>
+              <Th>Actions</Th>
             </Tr>
-          ) : (
-            draftBuilds.map(build => (
-              <BuildReviewRow
-                key={`${build.userAddress}_${build.id}`}
-                build={build}
-                isLoading={isLoadingDraftBuilds}
-                approveClick={handleSendBuildReview("ACCEPTED")}
-                rejectClick={handleSendBuildReview("REJECTED")}
-              />
-            ))
-          )}
-        </Tbody>
-      </Table>
+          </Thead>
+          <Tbody>
+            {!draftBuilds || draftBuilds.length === 0 ? (
+              <Tr>
+                <Td colSpan={5}>
+                  <Text color={secondaryFontColor} textAlign="center" mb={4}>
+                    <Icon as={HeroIconInbox} w={6} h={6} color={secondaryFontColor} mt={6} mb={4} />
+                    <br />
+                    All builds have been reviewed
+                  </Text>
+                </Td>
+              </Tr>
+            ) : (
+              draftBuilds.map(build => (
+                <BuildReviewRow
+                  key={`${build.userAddress}_${build.id}`}
+                  build={build}
+                  isLoading={isLoadingDraftBuilds}
+                  approveClick={handleSendBuildReview("ACCEPTED")}
+                  rejectClick={handleSendBuildReview("REJECTED")}
+                />
+              ))
+            )}
+          </Tbody>
+        </Table>
       </Box>
     </Container>
   );


### PR DESCRIPTION
We don't want the branchURL anymore. We'll ask for the Etherscan contract URL.

- Change branchUrl => contractUrl
- Keep the legacy for branchUrl for already submitted challenges
- Add tooltip to the submission fields.