### PR TITLE
137/spinners before empty states

### DIFF
--- a/packages/react-app/src/components/BuildReviewRow.jsx
+++ b/packages/react-app/src/components/BuildReviewRow.jsx
@@ -1,7 +1,7 @@
 import React from "react";
 import moment from "moment";
 import { Link as RouteLink } from "react-router-dom";
-import { Button, Box, HStack, Link, Td, Tr, Tooltip } from "@chakra-ui/react";
+import { Button, Box, HStack, Link, Td, Tr, Tooltip, SkeletonText } from "@chakra-ui/react";
 import Address from "./Address";
 
 export default function BuildReviewRow({ build, submittedTimestamp, isLoading, approveClick, rejectClick }) {
@@ -21,9 +21,13 @@ export default function BuildReviewRow({ build, submittedTimestamp, isLoading, a
         </Link>
       </Td>
       <Td>
-        <Tooltip label={submittedMoment.format("YYYY-MM-DD, HH:mm")}>
-          <Box cursor="pointer">{submittedMoment.fromNow()}</Box>
-        </Tooltip>
+        {!submittedTimestamp ? (
+          <SkeletonText noOfLines={1} py={4} />
+        ) : (
+          <Tooltip label={submittedMoment.format("YYYY-MM-DD, HH:mm")}>
+            <Box cursor="pointer">{submittedMoment.fromNow()}</Box>
+          </Tooltip>
+        )}
       </Td>
       <Td>
         <HStack spacing={3}>

--- a/packages/react-app/src/components/ChallengeReviewRow.jsx
+++ b/packages/react-app/src/components/ChallengeReviewRow.jsx
@@ -30,6 +30,7 @@ import {
   TabPanel,
   ListItem,
   UnorderedList,
+  SkeletonText,
 } from "@chakra-ui/react";
 import ReactMarkdown from "react-markdown";
 import ChakraUIRenderer from "chakra-ui-markdown-renderer";
@@ -88,9 +89,13 @@ export default function ChallengeReviewRow({ challenge, submittedTimestamp, isLo
         </Link>
       </Td>
       <Td>
-        <Tooltip label={submittedMoment.format("YYYY-MM-DD, HH:mm")}>
-          <Box cursor="pointer">{submittedMoment.fromNow()}</Box>
-        </Tooltip>
+        {!submittedTimestamp ? (
+          <SkeletonText noOfLines={1} py={4} />
+        ) : (
+          <Tooltip label={submittedMoment.format("YYYY-MM-DD, HH:mm")}>
+            <Box cursor="pointer">{submittedMoment.fromNow()}</Box>
+          </Tooltip>
+        )}
       </Td>
     </>
   );

--- a/packages/react-app/src/components/skeletons/BuilderProfileChallengesTableSkeleton.jsx
+++ b/packages/react-app/src/components/skeletons/BuilderProfileChallengesTableSkeleton.jsx
@@ -1,0 +1,43 @@
+import React from "react";
+import { Box, Table, Thead, Tbody, Tr, Th, Td, SkeletonText } from "@chakra-ui/react";
+
+const BuilderProfileChallengesTableSkeleton = () => (
+  <Box overflowX="auto">
+    <Table>
+      <Thead>
+        <Tr>
+          <Th>Name</Th>
+          <Th>Contract</Th>
+          <Th>Live Demo</Th>
+          <Th>Updated</Th>
+          <Th>Status</Th>
+        </Tr>
+      </Thead>
+      <Tbody>
+        {[1, 2].map(lineNumber => {
+          return (
+            <Tr key={lineNumber}>
+              <Td>
+                <SkeletonText noOfLines={1} py={4} />
+              </Td>
+              <Td>
+                <SkeletonText noOfLines={1} py={4} />
+              </Td>
+              <Td>
+                <SkeletonText noOfLines={1} py={4} />
+              </Td>
+              <Td>
+                <SkeletonText noOfLines={1} py={4} />
+              </Td>
+              <Td>
+                <SkeletonText noOfLines={1} py={4} />
+              </Td>
+            </Tr>
+          );
+        })}
+      </Tbody>
+    </Table>
+  </Box>
+);
+
+export default BuilderProfileChallengesTableSkeleton;

--- a/packages/react-app/src/components/skeletons/BuilderProfileChallengesTableSkeleton.jsx
+++ b/packages/react-app/src/components/skeletons/BuilderProfileChallengesTableSkeleton.jsx
@@ -1,12 +1,12 @@
 import React from "react";
-import { Box, Table, Thead, Tbody, Tr, Th, Td, SkeletonText } from "@chakra-ui/react";
+import { Box, Table, Thead, Tbody, Tr, Th, Td, Skeleton, SkeletonText } from "@chakra-ui/react";
 
 const BuilderProfileChallengesTableSkeleton = () => (
   <Box overflowX="auto">
     <Table>
       <Thead>
         <Tr>
-          <Th>Name</Th>
+          <Th w="30%">Name</Th>
           <Th>Contract</Th>
           <Th>Live Demo</Th>
           <Th>Updated</Th>
@@ -18,19 +18,21 @@ const BuilderProfileChallengesTableSkeleton = () => (
           return (
             <Tr key={lineNumber}>
               <Td>
-                <SkeletonText noOfLines={1} py={4} />
+                <SkeletonText noOfLines={1} py={2} />
               </Td>
               <Td>
-                <SkeletonText noOfLines={1} py={4} />
+                <SkeletonText noOfLines={1} w="50%" />
               </Td>
               <Td>
-                <SkeletonText noOfLines={1} py={4} />
+                <SkeletonText noOfLines={1} w="50%" />
               </Td>
               <Td>
-                <SkeletonText noOfLines={1} py={4} />
+                <SkeletonText noOfLines={1} />
               </Td>
               <Td>
-                <SkeletonText noOfLines={1} py={4} />
+                <Skeleton h={6} w={20} borderRadius="full">
+                  Submitted
+                </Skeleton>
               </Td>
             </Tr>
           );

--- a/packages/react-app/src/components/skeletons/SkeletonAddress.jsx
+++ b/packages/react-app/src/components/skeletons/SkeletonAddress.jsx
@@ -1,0 +1,26 @@
+import React from "react";
+import { HStack, Skeleton } from "@chakra-ui/react";
+import QRPunkBlockie from "../QrPunkBlockie";
+
+const SkeletonAddress = ({ fontSize, w }) => (
+  <HStack spacing="20px">
+    <Skeleton>
+      <span style={{ verticalAlign: "middle" }}>
+        <QRPunkBlockie withQr={false} address="0xf39F" w={w ?? 12.5} borderRadius="md" />
+      </span>
+    </Skeleton>
+    <Skeleton>
+      <span
+        style={{
+          verticalAlign: "middle",
+          fontSize: fontSize ?? 28,
+          fontWeight: "bold",
+        }}
+      >
+        0xf39F
+      </span>
+    </Skeleton>
+  </HStack>
+);
+
+export default SkeletonAddress;

--- a/packages/react-app/src/components/skeletons/SubmissionReviewTableSkeleton.jsx
+++ b/packages/react-app/src/components/skeletons/SubmissionReviewTableSkeleton.jsx
@@ -1,0 +1,104 @@
+import React from "react";
+import { Box, Button, Table, Thead, Tbody, Tr, Th, Td, HStack, Skeleton, SkeletonText } from "@chakra-ui/react";
+import SkeletonAddress from "./SkeletonAddress";
+
+export const BuildsTableSkeleton = () => (
+  <Box overflowX="auto">
+    <Table mb={4}>
+      <Thead>
+        <Tr>
+          <Th>Builder</Th>
+          <Th>Build Name</Th>
+          <Th>Description</Th>
+          <Th>Branch URL</Th>
+          <Th>Submitted time</Th>
+          <Th>Actions</Th>
+        </Tr>
+      </Thead>
+      <Tbody>
+        {[1, 2].map(lineNumber => {
+          return (
+            <Tr key={lineNumber}>
+              <Td>
+                <SkeletonAddress w="12.5" fontSize="16" />
+              </Td>
+              <Td>
+                <SkeletonText noOfLines={1} py={4} />
+              </Td>
+              <Td>
+                <SkeletonText noOfLines={1} py={4} />
+              </Td>
+              <Td>
+                <SkeletonText noOfLines={1} py={4} />
+              </Td>
+              <Td>
+                <SkeletonText noOfLines={1} py={4} />
+              </Td>
+              <Td>
+                <HStack spacing={3}>
+                  <Skeleton startColor="red.100" endColor="red.500">
+                    <Button type="button" size="xs">
+                      Reject
+                    </Button>
+                  </Skeleton>
+                  <Skeleton startColor="green.100" endColor="green.500">
+                    <Button type="button" style={{ marginRight: 10 }} size="xs">
+                      Approve
+                    </Button>
+                  </Skeleton>
+                </HStack>
+              </Td>
+            </Tr>
+          );
+        })}
+      </Tbody>
+    </Table>
+  </Box>
+);
+
+export const ChallengesTableSkeleton = () => (
+  <Box overflowX="auto">
+    <Table mb={4}>
+      <Thead>
+        <Tr>
+          <Th>Builder</Th>
+          <Th>Challenge</Th>
+          <Th>Contract</Th>
+          <Th>Live demo</Th>
+          <Th>Submitted time</Th>
+          <Th>Actions</Th>
+        </Tr>
+      </Thead>
+      <Tbody>
+        {[1, 2].map(lineNumber => {
+          return (
+            <Tr key={lineNumber}>
+              <Td>
+                <SkeletonAddress w="12.5" fontSize="16" />
+              </Td>
+              <Td>
+                <SkeletonText noOfLines={1} py={4} />
+              </Td>
+              <Td>
+                <SkeletonText noOfLines={1} py={4} />
+              </Td>
+              <Td>
+                <SkeletonText noOfLines={1} py={4} />
+              </Td>
+              <Td>
+                <SkeletonText noOfLines={1} py={4} />
+              </Td>
+              <Td>
+                <Skeleton startColor="blue.100" endColor="blue.500">
+                  <Button type="button" size="xs">
+                    Send review
+                  </Button>
+                </Skeleton>
+              </Td>
+            </Tr>
+          );
+        })}
+      </Tbody>
+    </Table>
+  </Box>
+);


### PR DESCRIPTION
In both pages there are 2 requests: one for the general data, another for the timestamps. Note how the skeleton stays on the timestamps until the request for the timestamps finishes.

This is how they look:
### Profile view
![profile page loading](https://user-images.githubusercontent.com/17493200/146367052-18573a35-68ef-4e79-ba91-013e97f1aff4.gif)

### Submissions view
![submission review loading](https://user-images.githubusercontent.com/17493200/146367078-1e105126-8a77-4b60-8d17-e0f418f93c0e.gif)

Side note: we should probably fix the ugly skeleton used for the blockie in the user profile. In this PR I created a new folder for skeletons and it's quite easy to build one looking quite similar to the actual view.