### PR TITLE
Change naming for the build events

### DIFF
--- a/packages/backend/routes/builds.js
+++ b/packages/backend/routes/builds.js
@@ -54,7 +54,7 @@ router.post("/", withRole("builder"), async (request, response) => {
     buildId: dbResponse.id,
   };
 
-  const event = createEvent(EVENT_TYPES.BUILD_CREATE, eventPayload, signature);
+  const event = createEvent(EVENT_TYPES.BUILD_SUBMIT, eventPayload, signature);
   db.createEvent(event); // INFO: async, no await here
 
   response.sendStatus(200);
@@ -65,7 +65,7 @@ router.post("/", withRole("builder"), async (request, response) => {
  */
 router.patch("/", withRole("admin"), async (request, response) => {
   console.log("PATCH /builds");
-  const { buildId, newStatus, signature } = request.body;
+  const { buildId, newStatus, signature, userAddress } = request.body;
   const address = request.address;
 
   const verifyOptions = {
@@ -90,6 +90,15 @@ router.patch("/", withRole("admin"), async (request, response) => {
   } else if (newStatus === "REJECTED") {
     await db.removeBuild(buildId);
   }
+
+  const eventPayload = {
+    reviewAction: newStatus,
+    userAddress,
+    reviewerAddress: address,
+    buildId,
+  };
+  const event = createEvent(EVENT_TYPES.BUILD_REVIEW, eventPayload, signature);
+  db.createEvent(event); // INFO: async, no await here
 
   response.sendStatus(200);
 });

--- a/packages/backend/utils/events.js
+++ b/packages/backend/utils/events.js
@@ -1,7 +1,6 @@
 const EVENT_TYPES = {
   CHALLENGE_SUBMIT: "challenge.submit",
   CHALLENGE_REVIEW: "challenge.review",
-  CHALLENGE_CREATE: "challenge.create",
   USER_CREATE: "user.create",
   USER_UPDATE: "user.update",
   BUILD_CREATE: "build.create",

--- a/packages/backend/utils/events.js
+++ b/packages/backend/utils/events.js
@@ -1,9 +1,10 @@
 const EVENT_TYPES = {
   CHALLENGE_SUBMIT: "challenge.submit",
   CHALLENGE_REVIEW: "challenge.review",
+  BUILD_SUBMIT: "build.submit",
+  BUILD_REVIEW: "build.review",
   USER_CREATE: "user.create",
   USER_UPDATE: "user.update",
-  BUILD_CREATE: "build.create",
 };
 
 // TODO we could check here if the payload is correct for the type

--- a/packages/react-app/src/data/api.js
+++ b/packages/react-app/src/data/api.js
@@ -37,7 +37,7 @@ export const getSubmitChallengeEventsForUserAndChallenges = async (userId, chall
 
 export const getDraftBuildEventsForBuildId = async buildId => {
   try {
-    const response = await axios.get(`${serverUrl}/events?buildId=${buildId}&type=build.create`);
+    const response = await axios.get(`${serverUrl}/events?buildId=${buildId}&type=build.submit`);
     return response.data;
   } catch (err) {
     console.log(`error fetching draft build events for user build ${buildId}.`, err);

--- a/packages/react-app/src/helpers/events.js
+++ b/packages/react-app/src/helpers/events.js
@@ -2,9 +2,8 @@
 const EVENT_TYPES = {
   CHALLENGE_SUBMIT: "challenge.submit",
   CHALLENGE_REVIEW: "challenge.review",
-  // ToDo. Review this when #134 is done.
-  // https://github.com/moonshotcollective/scaffold-directory/issues/134
-  BUILD_SUBMIT: "build.create",
+  BUILD_SUBMIT: "build.submit",
+  BUILD_REVIEW: "build.review",
   USER_CREATE: "user.create",
   USER_UPDATE: "user.update",
 };
@@ -16,11 +15,15 @@ export const eventDisplay = ({ type, payload }) => {
     }
 
     case EVENT_TYPES.CHALLENGE_REVIEW: {
-      return `A challenge submitted has been ${payload.reviewAction.toLowerCase()}`;
+      return `A submitted challenge has been ${payload.reviewAction.toLowerCase()}`;
     }
 
     case EVENT_TYPES.BUILD_SUBMIT: {
-      return `just submitted a build!`;
+      return `just submitted a new build!`;
+    }
+
+    case EVENT_TYPES.BUILD_REVIEW: {
+      return `A submitted build has been ${payload.reviewAction.toLowerCase()}`;
     }
 
     case EVENT_TYPES.USER_CREATE: {

--- a/packages/react-app/src/helpers/events.js
+++ b/packages/react-app/src/helpers/events.js
@@ -2,7 +2,6 @@
 const EVENT_TYPES = {
   CHALLENGE_SUBMIT: "challenge.submit",
   CHALLENGE_REVIEW: "challenge.review",
-  CHALLENGE_CREATE: "challenge.create",
   // ToDo. Review this when #134 is done.
   // https://github.com/moonshotcollective/scaffold-directory/issues/134
   BUILD_SUBMIT: "build.create",


### PR DESCRIPTION
Fix #134 

- [x] Remove challenge.create
- [x] Add build.submit and build.review
  - [x] Migrate the existing `builds.create` (maybe just deleted them, since are tests)
  - [x] Change create => submit on build /POST
  - [x] Emit build.review on build /PATCH