### PR TITLE
Use timestmap from objects instead of fetching events

### DIFF
--- a/packages/react-app/src/components/BuildReviewRow.jsx
+++ b/packages/react-app/src/components/BuildReviewRow.jsx
@@ -1,10 +1,10 @@
 import React from "react";
 import { Link as RouteLink } from "react-router-dom";
-import { Button, HStack, Link, Td, Tr, SkeletonText } from "@chakra-ui/react";
+import { Button, HStack, Link, Td, Tr } from "@chakra-ui/react";
 import Address from "./Address";
 import DateWithTooltip from "./DateWithTooltip";
 
-export default function BuildReviewRow({ build, submittedTimestamp, isLoading, approveClick, rejectClick }) {
+export default function BuildReviewRow({ build, isLoading, approveClick, rejectClick }) {
   return (
     <Tr>
       <Td>
@@ -20,11 +20,7 @@ export default function BuildReviewRow({ build, submittedTimestamp, isLoading, a
         </Link>
       </Td>
       <Td>
-        {!submittedTimestamp ? (
-          <SkeletonText noOfLines={1} py={4} />
-        ) : (
-          <DateWithTooltip timestamp={submittedTimestamp} />
-        )}
+        <DateWithTooltip timestamp={build.submittedTimestamp} />
       </Td>
       <Td>
         <HStack spacing={3}>

--- a/packages/react-app/src/components/ChallengeReviewRow.jsx
+++ b/packages/react-app/src/components/ChallengeReviewRow.jsx
@@ -29,7 +29,6 @@ import {
   TabPanel,
   ListItem,
   UnorderedList,
-  SkeletonText,
 } from "@chakra-ui/react";
 import ReactMarkdown from "react-markdown";
 import ChakraUIRenderer from "chakra-ui-markdown-renderer";
@@ -38,7 +37,7 @@ import DateWithTooltip from "./DateWithTooltip";
 import { challengeInfo } from "../data/challenges";
 import { chakraMarkdownComponents } from "../helpers/chakraMarkdownTheme";
 
-export default function ChallengeReviewRow({ challenge, submittedTimestamp, isLoading, approveClick, rejectClick }) {
+export default function ChallengeReviewRow({ challenge, isLoading, approveClick, rejectClick }) {
   const [comment, setComment] = React.useState(challenge.reviewComment ?? "");
   const { isOpen, onOpen, onClose } = useDisclosure();
 
@@ -62,7 +61,7 @@ export default function ChallengeReviewRow({ challenge, submittedTimestamp, isLo
     </Link>
   );
 
-  const submittedMoment = moment(submittedTimestamp);
+  const submittedMoment = moment(challenge.submittedTimestamp);
 
   const reviewRow = (
     <>
@@ -89,11 +88,7 @@ export default function ChallengeReviewRow({ challenge, submittedTimestamp, isLo
         </Link>
       </Td>
       <Td>
-        {!submittedTimestamp ? (
-          <SkeletonText noOfLines={1} py={4} />
-        ) : (
-          <DateWithTooltip timestamp={submittedTimestamp} />
-        )}
+        <DateWithTooltip timestamp={challenge.submittedTimestamp} />
       </Td>
     </>
   );

--- a/packages/react-app/src/data/api.js
+++ b/packages/react-app/src/data/api.js
@@ -23,28 +23,6 @@ export const getChallengeEventsForUser = async userId => {
   }
 };
 
-export const getSubmitChallengeEventsForUserAndChallenges = async (userId, challengeIds) => {
-  try {
-    const response = await axios.get(
-      `${serverUrl}/events?user=${userId}&type=challenge.submit&challengeId=${challengeIds.join(",")}`,
-    );
-    return response.data;
-  } catch (err) {
-    console.log(`error fetching submit challenge events for user ${userId}.`, err);
-    return [];
-  }
-};
-
-export const getDraftBuildEventsForBuildId = async buildId => {
-  try {
-    const response = await axios.get(`${serverUrl}/events?buildId=${buildId}&type=build.submit`);
-    return response.data;
-  } catch (err) {
-    console.log(`error fetching draft build events for user build ${buildId}.`, err);
-    return [];
-  }
-};
-
 export const getAllBuilds = async () => {
   try {
     const response = await axios.get(`${serverUrl}/builds`);

--- a/packages/react-app/src/helpers/sorting.js
+++ b/packages/react-app/src/helpers/sorting.js
@@ -1,1 +1,3 @@
 export const byTimestamp = (a, b) => a.timestamp - b.timestamp;
+
+export const bySubmittedTimestamp = (a, b) => a.submittedTimestamp - b.submittedTimestamp;

--- a/packages/react-app/src/views/SubmissionReviewView.jsx
+++ b/packages/react-app/src/views/SubmissionReviewView.jsx
@@ -29,6 +29,7 @@ import {
   patchChallengeReview,
 } from "../data/api";
 import HeroIconInbox from "../components/icons/HeroIconInbox";
+import { bySubmittedTimestamp } from "../helpers/sorting";
 
 const RUBRIC_URL = "https://docs.google.com/document/d/1ByXQUUg-ePq0aKkMywOHV25ZetesI2BFYoJzSez009c";
 
@@ -56,7 +57,7 @@ export default function SubmissionReviewView({ userProvider }) {
       setIsLoadingChallenges(false);
       return;
     }
-    setChallenges(fetchedChallenges);
+    setChallenges(fetchedChallenges.sort(bySubmittedTimestamp));
     setIsLoadingChallenges(false);
   }, [address, toastVariant, toast]);
 
@@ -74,7 +75,7 @@ export default function SubmissionReviewView({ userProvider }) {
       setIsLoadingDraftBuilds(false);
       return;
     }
-    setDraftBuilds(fetchedDraftBuilds);
+    setDraftBuilds(fetchedDraftBuilds.sort(bySubmittedTimestamp));
     setIsLoadingDraftBuilds(false);
   }, [address, toastVariant, toast]);
 


### PR DESCRIPTION
fix #139 

Besides using timestamps from objects, with this PR we also sort the submissions by ASC timestamps, i.e. oldest first (smallest timestamp first).