### PR TITLE
Submission sorting and filtering

### DIFF
--- a/packages/react-app/src/components/icons/HeroIconFilter.jsx
+++ b/packages/react-app/src/components/icons/HeroIconFilter.jsx
@@ -1,0 +1,16 @@
+/* eslint react/jsx-props-no-spreading: off */
+// ☝️ we want this component to be usable with chakra props
+import React from "react";
+import { chakra } from "@chakra-ui/react";
+
+const HeroIconFilter = props => (
+  <chakra.svg {...props} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+    <path
+      fillRule="evenodd"
+      d="M3 3a1 1 0 011-1h12a1 1 0 011 1v3a1 1 0 01-.293.707L12 11.414V15a1 1 0 01-.293.707l-2 2A1 1 0 018 17v-5.586L3.293 6.707A1 1 0 013 6V3z"
+      clipRule="evenodd"
+    />
+  </chakra.svg>
+);
+
+export default HeroIconFilter;

--- a/packages/react-app/src/components/skeletons/SubmissionReviewTableSkeleton.jsx
+++ b/packages/react-app/src/components/skeletons/SubmissionReviewTableSkeleton.jsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { Box, Button, Table, Thead, Tbody, Tr, Th, Td, HStack, Skeleton, SkeletonText } from "@chakra-ui/react";
+import { TriangleDownIcon } from "@chakra-ui/icons";
 import SkeletonAddress from "./SkeletonAddress";
 
 export const BuildsTableSkeleton = () => (
@@ -65,7 +66,12 @@ export const ChallengesTableSkeleton = () => (
           <Th>Challenge</Th>
           <Th>Contract</Th>
           <Th>Live demo</Th>
-          <Th>Submitted time</Th>
+          <Th>
+            <HStack>
+              <span>Submitted time</span>
+              <TriangleDownIcon />
+            </HStack>
+          </Th>
           <Th>Actions</Th>
         </Tr>
       </Thead>

--- a/packages/react-app/src/helpers/sorting.js
+++ b/packages/react-app/src/helpers/sorting.js
@@ -1,3 +1,11 @@
+export const SORTING_ORDER = {
+  ascending: "sorting_ascending",
+  descending: "sorting_descending",
+};
+
 export const byTimestamp = (a, b) => a.timestamp - b.timestamp;
 
-export const bySubmittedTimestamp = (a, b) => a.submittedTimestamp - b.submittedTimestamp;
+export const bySubmittedTimestamp =
+  (order = SORTING_ORDER.ascending) =>
+  (a, b) =>
+    (a.submittedTimestamp - b.submittedTimestamp) * (order === SORTING_ORDER.descending ? -1 : 1);

--- a/packages/react-app/src/hooks/useCustomColorModes.js
+++ b/packages/react-app/src/hooks/useCustomColorModes.js
@@ -8,6 +8,7 @@ const useCustomColorModes = () => {
   const borderColor = dividerColor;
   const codeBgColor = useColorModeValue("gray.100", "gray.900");
   const iconBgColor = codeBgColor;
+  const iconInactiveColor = useColorModeValue("gray.200", "gray.700");
 
   return {
     primaryFontColor,
@@ -17,6 +18,7 @@ const useCustomColorModes = () => {
     codeFontColor,
     codeBgColor,
     iconBgColor,
+    iconInactiveColor,
   };
 };
 

--- a/packages/react-app/src/views/SubmissionReviewView.jsx
+++ b/packages/react-app/src/views/SubmissionReviewView.jsx
@@ -2,6 +2,7 @@ import React, { useCallback, useEffect, useState } from "react";
 import { useUserAddress } from "eth-hooks";
 import {
   useColorModeValue,
+  useDisclosure,
   Box,
   Container,
   HStack,
@@ -15,6 +16,10 @@ import {
   Tr,
   Th,
   Td,
+  Menu,
+  MenuButton,
+  MenuList,
+  MenuItem,
   useToast,
 } from "@chakra-ui/react";
 import { TriangleUpIcon, TriangleDownIcon } from "@chakra-ui/icons";
@@ -31,6 +36,7 @@ import {
   patchChallengeReview,
 } from "../data/api";
 import HeroIconInbox from "../components/icons/HeroIconInbox";
+import HeroIconFilter from "../components/icons/HeroIconFilter";
 import { SORTING_ORDER, bySubmittedTimestamp } from "../helpers/sorting";
 
 const RUBRIC_URL = "https://docs.google.com/document/d/1ByXQUUg-ePq0aKkMywOHV25ZetesI2BFYoJzSez009c";
@@ -42,9 +48,10 @@ export default function SubmissionReviewView({ userProvider }) {
   const [draftBuilds, setDraftBuilds] = React.useState([]);
   const [isLoadingDraftBuilds, setIsLoadingDraftBuilds] = React.useState(true);
   const [challengesSorting, setChallengesSorting] = useState(SORTING_ORDER.ascending);
+  const { isOpen, onOpen, onClose } = useDisclosure();
   const toast = useToast({ position: "top", isClosable: true });
   const toastVariant = useColorModeValue("subtle", "solid");
-  const { secondaryFontColor } = useCustomColorModes();
+  const { secondaryFontColor, iconInactiveColor } = useCustomColorModes();
 
   const toggleChallengeSortingOrder = () =>
     setChallengesSorting(prevSorting => {
@@ -231,14 +238,29 @@ export default function SubmissionReviewView({ userProvider }) {
         Challenges
       </Heading>
       <Box overflowX="auto">
-        {isLoadingChallenges ? (
+        {false ? (
           <ChallengesTableSkeleton />
         ) : (
           <Table>
             <Thead>
               <Tr>
-                <Th>Builder</Th>
-                <Th>Challenge</Th>
+                <Th>User</Th>
+                <Th>
+                  <Menu as={React.Fragment}>
+                    <MenuButton as={HStack} cursor="pointer">
+                      {/* <HStack cursor="pointer"> */}
+                      <span>Country</span>
+                      <HeroIconFilter h={4} w={4} color={iconInactiveColor} />
+                      {/* </HStack> */}
+                    </MenuButton>
+                    <MenuList>
+                      <MenuItem>first</MenuItem>
+                      <MenuItem>second</MenuItem>
+                    </MenuList>
+                  </Menu>
+                </Th>
+                {/* <Th onClick={onOpen} >
+                </Th> */}
                 <Th>Contract</Th>
                 <Th>Live demo</Th>
                 <Th onClick={toggleChallengeSortingOrder} cursor="pointer">
@@ -297,7 +319,7 @@ export default function SubmissionReviewView({ userProvider }) {
             <Tbody>
               {!draftBuilds || draftBuilds.length === 0 ? (
                 <Tr>
-                  <Td colSpan={5}>
+                  <Td colSpan={6}>
                     <Text color={secondaryFontColor} textAlign="center" mb={4}>
                       <Icon as={HeroIconInbox} w={6} h={6} color={secondaryFontColor} mt={6} mb={4} />
                       <br />


### PR DESCRIPTION
This solves part of #148
- [x] Table sorting by clicking the table header titles.
- [ ] For resubmitted challenges. show the last reviewer address/ens for a given builder-challenge pair.

This is probably worth a separate PR
- Telegram bot to send notifications to the telegram group. (make sure we really want this)